### PR TITLE
Feat/branch name strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Turbo Version is a monorepo solution for managing package versions and releasing
 
 Turbo Version includes the following packages:
 
-- `@turbo-version/version`: A package version management tool for monorepos. It allows you to manage versions of packages across multiple projects and release new versions of packages.
+- `@turbo-version/version`: A package version management tool for monorepos. It allows you to manage versions of packages across multiple projects and release new versions of packages.[Docs](packages/turbo-version/README.md)
 
-- `@turbo-version/release`: A command-line interface tool for publishing packages inside Turbo repos to the npm registry with version validation. This tool validates whether a package version has already been published on the registry before attempting to publish it.
+- `@turbo-version/release`: A command-line interface-tool for publishing packages inside Turbo repos to the npm registry with version validation. This tool validates whether a package version has already been published on the registry before attempting to publish it.[Docs](packages/turbo-release/README.md)
 
 ## Installation
 

--- a/packages/turbo-git/src/index.ts
+++ b/packages/turbo-git/src/index.ts
@@ -176,7 +176,7 @@ export function lastMergeBranchName() {
     const lastBranchName = execSync("git symbolic-ref --short HEAD", {
       encoding: "utf-8",
     });
-    return lastBranchName;
+    return lastBranchName.toString().trim();
   } catch (error: any) {
     console.error("Error while getting the last branch name:", error.message);
     return null;

--- a/packages/turbo-git/src/index.ts
+++ b/packages/turbo-git/src/index.ts
@@ -170,3 +170,15 @@ export async function gitProcess({
     throw new Error(`Failed to create new version: ${err.message}`);
   }
 }
+
+export function lastMergeBranchName() {
+  try {
+    const lastBranchName = execSync("git symbolic-ref --short HEAD", {
+      encoding: "utf-8",
+    });
+    return lastBranchName;
+  } catch (error: any) {
+    console.error("Error while getting the last branch name:", error.message);
+    return null;
+  }
+}

--- a/packages/turbo-git/src/index.ts
+++ b/packages/turbo-git/src/index.ts
@@ -174,9 +174,8 @@ export async function gitProcess({
 export async function lastMergeBranchName(baseBranch: string) {
   try {
     const lastBranchName = await execAsync(
-      `git branch --merged ${baseBranch} | grep -v "${baseBranch}" | tail -n 1`
+      `git branch --contains $(git rev-parse $(git rev-list --merges --first-parent ${baseBranch} | tail -n 2 | head -n 1)) | grep -v "${baseBranch}" | awk '{print $NF}'`
     );
-
     return lastBranchName.stdout.trim();
   } catch (error: any) {
     console.error("Error while getting the last branch name:", error.message);

--- a/packages/turbo-git/src/index.ts
+++ b/packages/turbo-git/src/index.ts
@@ -171,12 +171,11 @@ export async function gitProcess({
   }
 }
 
-export function lastMergeBranchName() {
+export async function lastMergeBranchName() {
   try {
-    const lastBranchName = execSync("git symbolic-ref --short HEAD", {
-      encoding: "utf-8",
-    });
-    return lastBranchName.toString().trim();
+    const lastBranchName = await execAsync("git log --merges --format=%H -n 1");
+    console.log(lastBranchName.stdout, `<<<<<<<<<,s`);
+    return lastBranchName.stdout.trim();
   } catch (error: any) {
     console.error("Error while getting the last branch name:", error.message);
     return null;

--- a/packages/turbo-git/src/index.ts
+++ b/packages/turbo-git/src/index.ts
@@ -171,10 +171,12 @@ export async function gitProcess({
   }
 }
 
-export async function lastMergeBranchName() {
+export async function lastMergeBranchName(baseBranch: string) {
   try {
-    const lastBranchName = await execAsync("git log --merges --format=%H -n 1");
-    console.log(lastBranchName.stdout, `<<<<<<<<<,s`);
+    const lastBranchName = await execAsync(
+      `git branch --merged ${baseBranch} | grep -v "${baseBranch}" | tail -n 1`
+    );
+
     return lastBranchName.stdout.trim();
   } catch (error: any) {
     console.error("Error while getting the last branch name:", error.message);

--- a/packages/turbo-setup/src/index.ts
+++ b/packages/turbo-setup/src/index.ts
@@ -23,6 +23,8 @@ export type Config = {
   strategy: "first-release" | "next-release" | "last-release";
   skip?: string[];
   commitMessage?: string;
+  versionStrategy?: "branchName" | "commitMessage";
+  branchNamePattern?: string[];
 };
 
 export function setup(): Promise<Config> {

--- a/packages/turbo-setup/src/index.ts
+++ b/packages/turbo-setup/src/index.ts
@@ -24,7 +24,7 @@ export type Config = {
   skip?: string[];
   commitMessage?: string;
   versionStrategy?: "branchName" | "commitMessage";
-  branchNamePattern?: string[];
+  branchPattern: string[];
 };
 
 export function setup(): Promise<Config> {

--- a/packages/turbo-version/README.md
+++ b/packages/turbo-version/README.md
@@ -39,7 +39,9 @@ If there are no commit messages to determine the bump kind, the tool will defaul
 
 - `-b, --bump <version>`: Specifies the type of update. The available options are `patch`, `minor`, `major`, `premajor`, `preminor`, `prepatch`, `prerelease`. If not specified, all packages will be updated based on the commit messages since the last release.
 
-## Semantic Commit Messages
+## Two approaches to versioning
+
+### Semantic Commit Messages based versioning
 
 **Turbo Version** analyzes these semantic commit messages and automatically determines the appropriate version number to assign to the next release of the package. For example, if a commit message indicates that a bug was fixed, **Turbo Version** might increment the patch version number (e.g. from 1.2.3 to 1.2.4). If a commit message indicates that a new feature was added, **Turbo Version** might increment the minor version number (e.g. from 1.2.3 to 1.3.0).
 
@@ -47,7 +49,7 @@ Format: `<type>(<scope>): <subject>`
 
 `<scope>` is optional, but in a monorepo context, it's really helpful to determine the package that you worked.
 
-### Example
+#### Example
 
 ```
 feat: add hat wobble
@@ -74,6 +76,18 @@ References:
 - https://seesparkbox.com/foundry/semantic_commit_messages
 - http://karma-runner.github.io/1.0/dev/git-commit-msg.html
 
+### Branch name based versioning
+
+**TurboVersion** uses the Git branch name to determine the next version, by default TurboVersion will use [`major`, `minor`, `patch`] as the branch name pattern, for example, if your current version is 1.2.3, and you have a branch named `patch`, the next version will be 1.2.4 when the `patch` branch is merged into the `main` branch.
+
+#### Configuration
+
+To use branch name-based versioning, you need to configure the `version.config.json` file with the following properties:
+
+- `baseBranch` - the main branch name, it's used to calculate the next version.
+- `versionStrategy` - the versioning strategy should be `branchName`.
+- `branchPattern` - the branch name pattern used to calculate the next version (optional, by default, it's [`major`, `minor`, `patch`]).
+
 ## `version.config.json`
 
 This is a JSON schema used to configure the versioning process for a project. The schema provides several properties that can be customized to control how versions are created and managed.
@@ -83,12 +97,14 @@ This is a JSON schema used to configure the versioning process for a project. Th
 The following properties are defined in the schema:
 
 - `tagPrefix`: A string property that represents the prefix used for Git tags in the project. This property is usually set to the name of the project. `${projectName}@` or just `v` for synced workspaces.
-- `preset`: A property that specifies the commit message convention preset used by the commitizen tool in the project. The property is a string with a default value of "angular" and can only take one of the two possible string values - "angular" or "conventional".
+- `preset`: A property that specifies the commit message convention preset used by the commitizen tool in the project. The property is a string with a default value of "angular" and can only take one of the two possible string values - "angular" or "conventional".(Only used if `versionStrategy` is set to "commitMessage").
 - `baseBranch`: A string property that represents the Git branch that should be used as the base for versioning in the project.
 - `synced`: A boolean property that indicates whether or not the local Git repository is synced with the remote repository.
 - `updateInternalDependencies`: A property that specifies how to update internal dependencies between packages. The property is a string with a default value of "patch" and can only take one of the three possible string values - "major", "minor", or "patch". Alternatively, the property can be set to the boolean value `false` to disable automatic updates.
 - `skip`: A list of package names that should be excluded from the versioning process. When you specify one or more package names in this list, those packages will be skipped in the versioning process. This is useful when you have packages that don't need to be versioned, or that require additional steps before they can be published.
 - `commitMessage`: A string property that represents the commit message pattern used by the commitizen tool in the project. This property is a regular expression. Example: `chore(new version): release version ${version} [skip-ci]` or `chore(${packageName}): release version ${version} [skip-ci]`.
+- `versionStrategy`: A string property that specifies the versioning strategy. The property can be set to either "branchName" or "commitMessage". By default, it's set to "commitMessage".
+- `branchPattern`: An array property that represents the branch name pattern used to calculate the next version. By default, it's set to [`major`, `minor`, `patch`](Applyed just when `versionStrategy` is set to "branchName").
 
 ### Required Properties
 

--- a/packages/turbo-version/src/AsyncFlux.ts
+++ b/packages/turbo-version/src/AsyncFlux.ts
@@ -10,6 +10,7 @@ import { summarizePackages } from "@turbo-version/dependents";
 import { Config } from "@turbo-version/setup";
 import { cwd, exit } from "process";
 import { formatCommitMessage } from "./utils/TemplateString";
+import { generateVersionByBranchName } from "./utils/GenerateVersionByBranchName";
 
 export async function asyncFlux(config: Config, type?: any) {
   const { preset, baseBranch: branch } = config;
@@ -47,14 +48,26 @@ export async function asyncFlux(config: Config, type?: any) {
           synced: config.synced,
         });
         const latestTag = await getLatestTag(tagPrefix);
-        const version = await generateVersion({
-          latestTag,
-          preset,
-          tagPrefix,
-          type: type ?? pkg.type,
-          path,
-          name,
-        });
+
+        let version: string | null = null;
+
+        if (config.versionStrategy === "branchName") {
+          version = await generateVersionByBranchName({
+            latestTag,
+            tagPrefix,
+            type: type ?? pkg.type,
+            path,
+          });
+        } else {
+          version = await generateVersion({
+            latestTag,
+            preset,
+            tagPrefix,
+            type: type ?? pkg.type,
+            path,
+            name,
+          });
+        }
 
         if (version) {
           log(["new", `New version calculated ${version}`, name]);

--- a/packages/turbo-version/src/AsyncFlux.ts
+++ b/packages/turbo-version/src/AsyncFlux.ts
@@ -57,6 +57,7 @@ export async function asyncFlux(config: Config, type?: any) {
             tagPrefix,
             type: type ?? pkg.type,
             path,
+            branchPattern: config.branchNamePattern as ""[],
           });
         } else {
           version = await generateVersion({

--- a/packages/turbo-version/src/AsyncFlux.ts
+++ b/packages/turbo-version/src/AsyncFlux.ts
@@ -8,12 +8,12 @@ import { gitProcess } from "@turbo-version/git";
 import { log } from "@turbo-version/log";
 import { summarizePackages } from "@turbo-version/dependents";
 import { Config } from "@turbo-version/setup";
-import { cwd, exit } from "process";
+import { exit } from "process";
 import { formatCommitMessage } from "./utils/TemplateString";
 import { generateVersionByBranchName } from "./utils/GenerateVersionByBranchName";
 
 export async function asyncFlux(config: Config, type?: any) {
-  const { preset, baseBranch: branch } = config;
+  const { preset, baseBranch, branchPattern } = config;
 
   try {
     const packages = await summarizePackages(config);
@@ -57,7 +57,8 @@ export async function asyncFlux(config: Config, type?: any) {
             tagPrefix,
             type: type ?? pkg.type,
             path,
-            branchPattern: config.branchNamePattern as ""[],
+            branchPattern,
+            baseBranch,
           });
         } else {
           version = await generateVersion({

--- a/packages/turbo-version/src/SingleFlux.ts
+++ b/packages/turbo-version/src/SingleFlux.ts
@@ -43,6 +43,7 @@ export async function singleFlux(config: Config, options: any) {
           tagPrefix,
           type,
           path,
+          branchPattern: config.branchNamePattern as ""[],
         });
       } else {
         version = await generateVersion({

--- a/packages/turbo-version/src/SingleFlux.ts
+++ b/packages/turbo-version/src/SingleFlux.ts
@@ -13,7 +13,7 @@ import { formatCommitMessage } from "./utils/TemplateString";
 import { generateVersionByBranchName } from "./utils/GenerateVersionByBranchName";
 
 export async function singleFlux(config: Config, options: any) {
-  const { preset } = config;
+  const { preset, baseBranch, branchPattern } = config;
   const pkgNames: string[] = options.target.split(",");
   const type = options.bump;
   const { packages: pkgs } = getPackagesSync(cwd());
@@ -43,7 +43,8 @@ export async function singleFlux(config: Config, options: any) {
           tagPrefix,
           type,
           path,
-          branchPattern: config.branchNamePattern as ""[],
+          branchPattern,
+          baseBranch,
         });
       } else {
         version = await generateVersion({

--- a/packages/turbo-version/src/SingleFlux.ts
+++ b/packages/turbo-version/src/SingleFlux.ts
@@ -10,6 +10,7 @@ import { cwd, exit } from "process";
 import chalk from "chalk";
 import { getPackagesSync } from "@manypkg/get-packages";
 import { formatCommitMessage } from "./utils/TemplateString";
+import { generateVersionByBranchName } from "./utils/GenerateVersionByBranchName";
 
 export async function singleFlux(config: Config, options: any) {
   const { preset } = config;
@@ -33,14 +34,26 @@ export async function singleFlux(config: Config, options: any) {
       });
 
       const latestTag = await getLatestTag(tagPrefix);
-      const version = await generateVersion({
-        latestTag,
-        preset,
-        tagPrefix,
-        type,
-        path,
-        name,
-      });
+
+      let version: string | null = null;
+
+      if (config.versionStrategy === "branchName") {
+        version = await generateVersionByBranchName({
+          latestTag,
+          tagPrefix,
+          type,
+          path,
+        });
+      } else {
+        version = await generateVersion({
+          latestTag,
+          preset,
+          tagPrefix,
+          type,
+          path,
+          name,
+        });
+      }
 
       if (version && name && version && path) {
         log(["new", `New version calculated ${version}`, name]);

--- a/packages/turbo-version/src/SyncedFlux.ts
+++ b/packages/turbo-version/src/SyncedFlux.ts
@@ -24,12 +24,12 @@ export async function syncedFlux(config: Config, type?: any) {
     const latestTag = await getLatestTag(tagPrefix);
 
     let version: string | null = null;
-
     if (config.versionStrategy === "branchName") {
       version = await generateVersionByBranchName({
         latestTag,
         tagPrefix,
         type,
+        branchPattern: config.branchNamePattern as ""[],
       });
     } else {
       version = await generateVersion({

--- a/packages/turbo-version/src/SyncedFlux.ts
+++ b/packages/turbo-version/src/SyncedFlux.ts
@@ -19,7 +19,7 @@ export async function syncedFlux(config: Config, type?: any) {
     const tagPrefix = formatTagPrefix({
       synced: config.synced,
     });
-    const { preset } = config;
+    const { preset, baseBranch, branchPattern } = config;
 
     const latestTag = await getLatestTag(tagPrefix);
 
@@ -29,7 +29,8 @@ export async function syncedFlux(config: Config, type?: any) {
         latestTag,
         tagPrefix,
         type,
-        branchPattern: config.branchNamePattern as ""[],
+        branchPattern,
+        baseBranch,
       });
     } else {
       version = await generateVersion({

--- a/packages/turbo-version/src/SyncedFlux.ts
+++ b/packages/turbo-version/src/SyncedFlux.ts
@@ -10,6 +10,7 @@ import chalk from "chalk";
 import { log } from "@turbo-version/log";
 import { getPackagesSync } from "@manypkg/get-packages";
 import { formatCommitMessage } from "./utils/TemplateString";
+import { generateVersionByBranchName } from "./utils/GenerateVersionByBranchName";
 
 export async function syncedFlux(config: Config, type?: any) {
   try {
@@ -22,12 +23,22 @@ export async function syncedFlux(config: Config, type?: any) {
 
     const latestTag = await getLatestTag(tagPrefix);
 
-    const version = await generateVersion({
-      latestTag,
-      preset,
-      tagPrefix,
-      type,
-    });
+    let version: string | null = null;
+
+    if (config.versionStrategy === "branchName") {
+      version = await generateVersionByBranchName({
+        latestTag,
+        tagPrefix,
+        type,
+      });
+    } else {
+      version = await generateVersion({
+        latestTag,
+        preset,
+        tagPrefix,
+        type,
+      });
+    }
 
     if (typeof version === "string") {
       log(["new", `New version calculated ${version}`, "All"]);

--- a/packages/turbo-version/src/index.ts
+++ b/packages/turbo-version/src/index.ts
@@ -42,8 +42,8 @@ program
     try {
       const config = await setup();
       if (config.versionStrategy === "branchName") {
-        if (!config.branchNamePattern) {
-          config.branchNamePattern = ["major", "minor", "branch"];
+        if (!config.branchPattern) {
+          config.branchPattern = ["major", "minor", "patch"];
         }
       }
       if (config.synced) {

--- a/packages/turbo-version/src/index.ts
+++ b/packages/turbo-version/src/index.ts
@@ -41,6 +41,11 @@ program
     );
     try {
       const config = await setup();
+      if (config.versionStrategy === "branchName") {
+        if (!config.branchNamePattern) {
+          config.branchNamePattern = ["major", "minor", "branch"];
+        }
+      }
       if (config.synced) {
         if (options.target) {
           console.log(

--- a/packages/turbo-version/src/utils/GenerateVersionByBranchName.ts
+++ b/packages/turbo-version/src/utils/GenerateVersionByBranchName.ts
@@ -4,32 +4,20 @@ import { getCommitsLength, lastMergeBranchName } from "@turbo-version/git";
 
 type Version = {
   latestTag: string;
-  preset: string;
   tagPrefix: string;
   type?: semver.ReleaseType;
   path?: string;
-  name?: string;
 };
 
 export async function generateVersion({
   latestTag,
-  preset,
   tagPrefix,
   type,
   path,
-  name,
 }: Version) {
   try {
-    const recommendation: any = await recommendedBumpAsync(
-      Object.assign(
-        {
-          preset,
-          tagPrefix,
-        },
-        path ? { lernaPackage: name, path } : {}
-      )
-    );
-    const recommended = genNexttagByBranchName(recommendation?.releaseType);
+    const recommended = genNextTagByBranchName(["master", "next"]);
+
     const currentVersion =
       semver.parse(latestTag.replace(tagPrefix, "")) ?? "0.0.0";
 
@@ -50,20 +38,20 @@ export async function generateVersion({
   }
 }
 
-function genNextTagByBranchName(schema: string[], currentVersion: string) {
+function genNextTagByBranchName(schema: string[]) {
   const branch = lastMergeBranchName();
 
-  switch (branch) {
-    case schema[0]:
-      return `${currentVersion.at(0) + 1}.0.0`;
-    case schema[1]:
-      return `${currentVersion.at(0)}.${currentVersion.at(1) + 1}.0`;
-    case schema[2]:
-      return `${currentVersion.at(0)}.${currentVersion.at(1)}.${
-        currentVersion.at(2) + 1
-      }`;
-
-    default:
-      return currentVersion.toString();
+  if (schema[0] === branch) {
+    return "major";
   }
+
+  if (schema[1] === branch) {
+    return "minor";
+  }
+
+  if (schema[2] === branch) {
+    return "patch";
+  }
+
+  return "patch";
 }

--- a/packages/turbo-version/src/utils/GenerateVersionByBranchName.ts
+++ b/packages/turbo-version/src/utils/GenerateVersionByBranchName.ts
@@ -8,6 +8,7 @@ type Version = {
   type?: semver.ReleaseType;
   path?: string;
   branchPattern: string[];
+  baseBranch?: string;
 };
 
 export async function generateVersionByBranchName({
@@ -16,9 +17,10 @@ export async function generateVersionByBranchName({
   type,
   path,
   branchPattern,
+  baseBranch,
 }: Version) {
   try {
-    const recommended = await genNextTagByBranchName(branchPattern);
+    const recommended = await genNextTagByBranchName(branchPattern, baseBranch);
 
     console.log({ recommended });
 

--- a/packages/turbo-version/src/utils/GenerateVersionByBranchName.ts
+++ b/packages/turbo-version/src/utils/GenerateVersionByBranchName.ts
@@ -1,0 +1,69 @@
+import semver from "semver";
+import { cwd } from "process";
+import { getCommitsLength, lastMergeBranchName } from "@turbo-version/git";
+
+type Version = {
+  latestTag: string;
+  preset: string;
+  tagPrefix: string;
+  type?: semver.ReleaseType;
+  path?: string;
+  name?: string;
+};
+
+export async function generateVersion({
+  latestTag,
+  preset,
+  tagPrefix,
+  type,
+  path,
+  name,
+}: Version) {
+  try {
+    const recommendation: any = await recommendedBumpAsync(
+      Object.assign(
+        {
+          preset,
+          tagPrefix,
+        },
+        path ? { lernaPackage: name, path } : {}
+      )
+    );
+    const recommended = genNexttagByBranchName(recommendation?.releaseType);
+    const currentVersion =
+      semver.parse(latestTag.replace(tagPrefix, "")) ?? "0.0.0";
+
+    const amountCommits = getCommitsLength(path ?? cwd());
+
+    if (latestTag && amountCommits === 0 && !type) {
+      return null;
+    }
+
+    const next = semver.inc(currentVersion, type ?? recommended);
+
+    if (!next) {
+      throw Error();
+    }
+    return next.toString();
+  } catch (error: any) {
+    throw Error(`Failed to calculate version: ${error.message}`);
+  }
+}
+
+function genNextTagByBranchName(schema: string[], currentVersion: string) {
+  const branch = lastMergeBranchName();
+
+  switch (branch) {
+    case schema[0]:
+      return `${currentVersion.at(0) + 1}.0.0`;
+    case schema[1]:
+      return `${currentVersion.at(0)}.${currentVersion.at(1) + 1}.0`;
+    case schema[2]:
+      return `${currentVersion.at(0)}.${currentVersion.at(1)}.${
+        currentVersion.at(2) + 1
+      }`;
+
+    default:
+      return currentVersion.toString();
+  }
+}

--- a/packages/turbo-version/src/utils/GenerateVersionByBranchName.ts
+++ b/packages/turbo-version/src/utils/GenerateVersionByBranchName.ts
@@ -7,6 +7,7 @@ type Version = {
   tagPrefix: string;
   type?: semver.ReleaseType;
   path?: string;
+  branchPattern: string[];
 };
 
 export async function generateVersionByBranchName({
@@ -14,9 +15,10 @@ export async function generateVersionByBranchName({
   tagPrefix,
   type,
   path,
+  branchPattern,
 }: Version) {
   try {
-    const recommended = genNextTagByBranchName(["master", "next"]);
+    const recommended = await genNextTagByBranchName(branchPattern);
 
     const currentVersion =
       semver.parse(latestTag.replace(tagPrefix, "")) ?? "0.0.0";
@@ -38,8 +40,10 @@ export async function generateVersionByBranchName({
   }
 }
 
-function genNextTagByBranchName(schema: string[]) {
-  const branch = lastMergeBranchName();
+async function genNextTagByBranchName(schema: string[]) {
+  const branch = await lastMergeBranchName();
+
+  console.log("generateVersionByBranchName", branch);
 
   if (schema[0] === branch) {
     return "major";

--- a/packages/turbo-version/src/utils/GenerateVersionByBranchName.ts
+++ b/packages/turbo-version/src/utils/GenerateVersionByBranchName.ts
@@ -20,6 +20,8 @@ export async function generateVersionByBranchName({
   try {
     const recommended = await genNextTagByBranchName(branchPattern);
 
+    console.log({ recommended });
+
     const currentVersion =
       semver.parse(latestTag.replace(tagPrefix, "")) ?? "0.0.0";
 
@@ -40,20 +42,21 @@ export async function generateVersionByBranchName({
   }
 }
 
-async function genNextTagByBranchName(schema: string[]) {
-  const branch = await lastMergeBranchName();
+async function genNextTagByBranchName(
+  schema: string[],
+  mainBranchName = "main"
+) {
+  const branch = await lastMergeBranchName(mainBranchName);
 
-  console.log("generateVersionByBranchName", branch);
-
-  if (schema[0] === branch) {
+  if (branch?.includes(schema[0])) {
     return "major";
   }
 
-  if (schema[1] === branch) {
+  if (branch?.includes(schema[1])) {
     return "minor";
   }
 
-  if (schema[2] === branch) {
+  if (branch?.includes(schema[2])) {
     return "patch";
   }
 

--- a/packages/turbo-version/src/utils/GenerateVersionByBranchName.ts
+++ b/packages/turbo-version/src/utils/GenerateVersionByBranchName.ts
@@ -9,7 +9,7 @@ type Version = {
   path?: string;
 };
 
-export async function generateVersion({
+export async function generateVersionByBranchName({
   latestTag,
   tagPrefix,
   type,

--- a/packages/turbo-version/version.schema.json
+++ b/packages/turbo-version/version.schema.json
@@ -6,6 +6,19 @@
             "type": "string",
             "description": "The prefix used for Git tags, usually the project name"
         },
+        "versionStrategy": {
+            "type": "string",
+            "enum": [
+                "branchName",
+                "commitMessage"
+            ],
+            "default": "commitMessage",
+            "description": "The versioning strategy to use, either 'branchName' or 'commitMessage'. Select 'branchName' if you want to calculate the version based on the branch name, and 'commitMessage' if you want to calculate the version based on the commit message.",
+            "examples": [
+                "branchName => v1.0.0 branchName 'patch*' => v1.0.1, branchName 'minor*' => v1.1.0, branchName 'major*' => v2.0.0",
+                "commitMessage => commit message follows the pattern feat/fix/refactor(context changed): release version"
+            ]
+        },
         "preset": {
             "oneOf": [
                 {
@@ -17,7 +30,19 @@
                     "default": "angular"
                 }
             ],
-            "description": "The commit message convention preset used by commitizen"
+            "description": "The commit message convention preset used by commitizen. That applies only when `versionStrategy` is 'commitMessage'"
+        },
+        "branchNamePattern": {
+            "type": "array",
+            "items": {
+                "type": "string",
+                "description": "Pattern to match the branch name"
+            },
+            "description": "The pattern to match the branch name. Only applies when `versionStrategy` is 'branchName'",
+            "examples": [
+                "[major, minor, patch] => [1.0.0, 1.1.0, 1.0.1]",
+                "[break, feat, fix] => [1.0.0, 1.1.0, 1.0.1]"
+            ]
         },
         "synced": {
             "type": "boolean",
@@ -57,7 +82,6 @@
     },
     "required": [
         "tagPrefix",
-        "preset",
         "baseBranch",
         "updateInternalDependencies"
     ]

--- a/packages/turbo-version/version.schema.json
+++ b/packages/turbo-version/version.schema.json
@@ -9,13 +9,13 @@
         "versionStrategy": {
             "type": "string",
             "enum": [
-                "branchName",
+                "branchPattern",
                 "commitMessage"
             ],
             "default": "commitMessage",
-            "description": "The versioning strategy to use, either 'branchName' or 'commitMessage'. Select 'branchName' if you want to calculate the version based on the branch name, and 'commitMessage' if you want to calculate the version based on the commit message.",
+            "description": "The versioning strategy to use, either 'branchPattern' or 'commitMessage'. Select 'branchPattern' if you want to calculate the version based on the branch name, and 'commitMessage' if you want to calculate the version based on the commit message.",
             "examples": [
-                "branchName => v1.0.0 branchName 'patch*' => v1.0.1, branchName 'minor*' => v1.1.0, branchName 'major*' => v2.0.0",
+                "branchPattern => v1.0.0 branchPattern 'patch*' => v1.0.1, branchPattern 'minor*' => v1.1.0, branchPattern 'major*' => v2.0.0",
                 "commitMessage => commit message follows the pattern feat/fix/refactor(context changed): release version"
             ]
         },
@@ -32,13 +32,13 @@
             ],
             "description": "The commit message convention preset used by commitizen. That applies only when `versionStrategy` is 'commitMessage'"
         },
-        "branchNamePattern": {
+        "branchPattern": {
             "type": "array",
             "items": {
                 "type": "string",
                 "description": "Pattern to match the branch name"
             },
-            "description": "The pattern to match the branch name. Only applies when `versionStrategy` is 'branchName'",
+            "description": "The pattern to match the branch name. Only applies when `versionStrategy` is 'branchPattern'",
             "examples": [
                 "[major, minor, patch] => [1.0.0, 1.1.0, 1.0.1]",
                 "[break, feat, fix] => [1.0.0, 1.1.0, 1.0.1]"


### PR DESCRIPTION
## Add branch name strategy

**TurboVersion** uses the Git branch name to determine the next version, by default TurboVersion will use [`major`, `minor`, `patch`] as the branch name pattern, for example, if your current version is 1.2.3, and you have a branch named `patch`, the next version will be 1.2.4 when the `patch` branch is merged into the `main` branch.