### PR TITLE
fix(turbo-git): the execSync function was calling exec.  exec is an a…

### DIFF
--- a/packages/turbo-git/src/index.ts
+++ b/packages/turbo-git/src/index.ts
@@ -1,4 +1,4 @@
-import { exec } from "child_process";
+import { exec, execSync as syncExec } from "child_process";
 import { existsSync, statSync } from "fs";
 import { join } from "path";
 import { cwd } from "process";
@@ -11,7 +11,7 @@ const execAsync = function (command: string) {
 };
 
 const execSync = function (command: string, args?: any) {
-  return exec(command, { maxBuffer: 1024 * 1024 * 10, ...args });
+  return syncExec(command, { maxBuffer: 1024 * 1024 * 10, ...args });
 };
 
 type GitTagOptions = {


### PR DESCRIPTION
…sync function

When exec is called from a sync function the response is a promise.  When you call toString on the promise you do not get the results of the command that was execured but rather a string like [Object].  Changed the execSync function to call the sync  version of the exec command.