### PR TITLE
feat: add `skipHooks` config setting

### DIFF
--- a/packages/turbo-git/src/index.ts
+++ b/packages/turbo-git/src/index.ts
@@ -24,12 +24,14 @@ type GitCommit = {
    amend?: boolean;
    author?: string;
    date?: string;
+   skipHooks?: boolean;
 };
 
 type GitProcess = {
    files: string[];
    nextTag: string;
    commitMessage: string;
+   skipHooks: boolean;
 };
 
 export async function pullBranch(branch: string) {
@@ -61,8 +63,10 @@ async function gitCommit(options: GitCommit) {
    if (options.date) {
       command.push(`--date="${options.date}"`);
    }
+   if (options.skipHooks) {
+      command.push("--no-verify");
+   }
    command.push(`-m "chore: ${options.message}"`);
-   command.push("--no-verify");
 
    return execAsync(`git ${command.join(" ")}`);
 }
@@ -144,6 +148,7 @@ export async function gitProcess({
    files,
    nextTag,
    commitMessage,
+   skipHooks = false,
 }: GitProcess) {
    try {
       if (!isGitRepository(cwd())) {
@@ -156,6 +161,7 @@ export async function gitProcess({
 
       await gitCommit({
          message: commitMessage,
+         skipHooks,
       });
 
       const tagMessage = `New Version ${nextTag} generated at ${new Date().toISOString()}`;

--- a/packages/turbo-setup/src/index.ts
+++ b/packages/turbo-setup/src/index.ts
@@ -26,6 +26,7 @@ export type Config = {
    versionStrategy?: "branchPattern" | "commitMessage";
    branchPattern: string[];
    prereleaseIdentifier?: string;
+   skipHooks?: boolean;
 };
 
 export function setup(): Promise<Config> {

--- a/packages/turbo-version/README.md
+++ b/packages/turbo-version/README.md
@@ -52,7 +52,7 @@ Format: `<type>(<scope>): <subject>`
 
 #### Example
 
-```
+```md
 feat: add hat wobble
 ^--^  ^------------^
 |     |
@@ -107,6 +107,7 @@ The following properties are defined in the schema:
 - `versionStrategy`: A string property that specifies the versioning strategy. The property can be set to either "branchPattern" or "commitMessage". By default, it's set to "commitMessage".
 - `branchPattern`: An array property that represents the branch name pattern used to calculate the next version. By default, it's set to [`major`, `minor`, `patch`(Applied just when `versionStrategy` is set to "branchPattern").
 - `prereleaseIdentifier`: String argument that will append the value of the string as a prerelease identifier `next | beta | alpha ...`
+- `skipHooks`: A boolean property that indicates whether the Git commit hooks are run or not.  Defaults to `false`.
 
 ### Required Properties
 

--- a/packages/turbo-version/src/AsyncFlux.ts
+++ b/packages/turbo-version/src/AsyncFlux.ts
@@ -100,6 +100,7 @@ export async function asyncFlux(config: Config, type?: ReleaseType) {
                   files: [path],
                   nextTag,
                   commitMessage,
+                  skipHooks: config.skipHooks,
                });
 
                log(["tag", `Git Tag generated for ${nextTag}.`, name]);

--- a/packages/turbo-version/src/SingleFlux.ts
+++ b/packages/turbo-version/src/SingleFlux.ts
@@ -86,6 +86,7 @@ export async function singleFlux(config: Config, options: any) {
                files: [path],
                nextTag,
                commitMessage,
+               skipHooks: config.skipHooks,
             });
             log(["tag", `Git Tag successfully generated.`, name]);
          } else {

--- a/packages/turbo-version/src/SyncedFlux.ts
+++ b/packages/turbo-version/src/SyncedFlux.ts
@@ -78,6 +78,7 @@ export async function syncedFlux(config: Config, type?: ReleaseType) {
             files: [cwd()],
             nextTag,
             commitMessage,
+            skipHooks: config.skipHooks,
          });
          log(["tag", `Git Tag generated for ${nextTag}.`, "All"]);
       } else {


### PR DESCRIPTION
Adding a new config setting to allow use of `--no-verify` only when the user wants to avoid triggering commit hooks.

Closes #7 