### PR TITLE
fix: prevent prerelease tag collisions (#26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Configure Turboversion to match your workflow:
   "skip": ["private-pkg"],
   "versionStrategy": "commitMessage",
   "branchPattern": ["major", "minor", "patch"],
-  "prereleaseIdentifier": "beta",
+  "prereleaseIdentifier": "beta.${branchName}",
   "skipHooks": false
 }
 ```
@@ -135,7 +135,17 @@ Configure Turboversion to match your workflow:
 | baseBranch            | Your main branch                   | main     |
 | sync                  | Sync versioning mode               | false    |
 | versionStrategy       | `commitMessage` or `branchPattern` | commitMessage |
-| prereleaseIdentifier  | Prerelease tag (e.g., beta)        | -        |
+| prereleaseIdentifier  | Prerelease tag (e.g., beta or beta.${branchName}) | -        |
+
+`prereleaseIdentifier` supports template values. Use `${branchName}` to keep prerelease streams isolated per branch:
+
+```json
+{
+  "prereleaseIdentifier": "beta.${branchName}"
+}
+```
+
+For example, `feature/auth-flow` generates a branch-specific prerelease identifier like `beta-feature-auth-flow` instead of sharing the same `beta.0`, `beta.1` sequence with other branches.
 
 ## PNPM Workflow (Recommended)
 

--- a/docs/content/docs/configuration/configuration.mdx
+++ b/docs/content/docs/configuration/configuration.mdx
@@ -38,17 +38,19 @@ Customize TurboVersion's behavior through a `version.config.json` file or CLI ar
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
 | `tagPrefix` | `string` | `"v"` | Prefix for Git tags (e.g., `pkg@1.0.0`) |
-| `prereleaseIdentifier` | `string` | `null` | Prerelease tag (e.g., `-beta`, `-alpha`) |
+| `prereleaseIdentifier` | `string` | `null` | Prerelease tag (e.g., `beta`, `alpha`, `beta.${branchName}`) |
 | `commitMessage` | `string` | `"chore(release): ${version} [skip-ci]"` | Template for release commits |
 
 **Custom Tag Example:**
 ```json
 {
   "tagPrefix": "pkg-",
-  "prereleaseIdentifier": "beta"
+  "prereleaseIdentifier": "beta.${branchName}"
 }
-// Generates tag: pkg-1.0.0-beta.1
+// On feature/auth-flow, generates a tag like: pkg-1.0.0-beta-feature-auth-flow.0
 ```
+
+`prereleaseIdentifier` supports `${branchName}`, `${packageName}`, and `${target}` templates. Template output is sanitized into a SemVer-safe identifier, so `beta.${branchName}` on `feature/auth-flow` becomes `beta-feature-auth-flow`. `${branchName}` is useful in prerelease pipelines because each feature branch gets its own prerelease stream instead of sharing one global `beta.0`, `beta.1` sequence.
 
 ### 🧩 Monorepo Controls
 
@@ -76,6 +78,14 @@ Customize TurboVersion's behavior through a `version.config.json` file or CLI ar
 | `baseBranch` | `string` | `"main"` | Branch to compare changes against |
 | `skipHooks` | `boolean` | `false` | Bypass Git commit hooks |
 | `analyzeCommitsSince` | `string` | `"last-release"` | Alternative: `"tag:v1.0.0"` |
+
+TurboVersion refreshes remote tags before calculating versions by running `git fetch --tags --force origin`. CI jobs should still use full checkout history so commit and tag analysis have the data they need:
+
+```yaml
+- uses: actions/checkout@v4
+  with:
+    fetch-depth: 0
+```
 
 ### ⚠️ Validation Rules
 

--- a/docs/content/docs/configuration/recipes.mdx
+++ b/docs/content/docs/configuration/recipes.mdx
@@ -97,7 +97,7 @@ release_job:
 ### 1. Prerelease Pipeline
 ```json
 {
-  "prereleaseIdentifier": "beta",
+  "prereleaseIdentifier": "beta.${branchName}",
   "branchPattern": ["release/"],
   "commitMessage": "chore(beta): v${version}"
 }
@@ -105,8 +105,10 @@ release_job:
 **Workflow**:
 ```bash
 git checkout -b release/v2
-turboversion --bump beta
+turboversion --prerelease
 ```
+
+Using `${branchName}` keeps prerelease tags from different branches out of the same sequence. For example, `feature/auth-flow` and `feature/search` can create independent prerelease tags instead of both competing for `v1.1.0-beta.0`.
 
 ### 2. Custom Changelog Groups
 ```json

--- a/docs/content/docs/references/cli-reference.mdx
+++ b/docs/content/docs/references/cli-reference.mdx
@@ -86,6 +86,16 @@ turboversion --bump minor
 turboversion --prerelease
 ```
 
+To isolate prerelease streams per branch, configure:
+
+```json
+{
+  "prereleaseIdentifier": "beta.${branchName}"
+}
+```
+
+TurboVersion fetches remote tags before calculating versions. In CI, keep `fetch-depth: 0` on checkout so commit and tag analysis has full history.
+
 ---
 
 ## Exit Codes

--- a/docs/content/docs/support/faq.mdx
+++ b/docs/content/docs/support/faq.mdx
@@ -84,6 +84,25 @@ Ensure you use:
 git push --follow-tags  # Critical for CI/CD
 ```
 
+TurboVersion fetches remote tags before calculating versions, but CI should still check out full history:
+
+```yaml
+- uses: actions/checkout@v4
+  with:
+    fetch-depth: 0
+```
+
+### Q: How do I avoid prerelease tag conflicts between feature branches?
+Use a branch-scoped prerelease identifier:
+
+```json
+{
+  "prereleaseIdentifier": "beta.${branchName}"
+}
+```
+
+This gives each branch its own prerelease sequence. The rendered value is sanitized, so `feature/auth-flow` becomes `beta-feature-auth-flow` and does not share the same `beta.0`, `beta.1` tags with `feature/search`.
+
 ---
 
 ## Advanced Usage

--- a/packages/version/README.md
+++ b/packages/version/README.md
@@ -117,7 +117,7 @@ Configure Turboversion to match your workflow:
   "skip": ["private-pkg"],
   "versionStrategy": "commitMessage",
   "branchPattern": ["major", "minor", "patch"],
-  "prereleaseIdentifier": "beta",
+  "prereleaseIdentifier": "beta.${branchName}",
   "skipHooks": false
 }
 ```
@@ -130,7 +130,17 @@ Configure Turboversion to match your workflow:
 | baseBranch            | Your main branch                   | main     |
 | sync                  | Sync versioning mode               | false    |
 | versionStrategy       | `commitMessage` or `branchPattern` | commitMessage |
-| prereleaseIdentifier  | Prerelease tag (e.g., beta)        | -        |
+| prereleaseIdentifier  | Prerelease tag (e.g., beta or beta.${branchName}) | -        |
+
+`prereleaseIdentifier` supports template values. Use `${branchName}` to keep prerelease streams isolated per branch:
+
+```json
+{
+  "prereleaseIdentifier": "beta.${branchName}"
+}
+```
+
+For example, `feature/auth-flow` generates a branch-specific prerelease identifier like `beta-feature-auth-flow` instead of sharing the same `beta.0`, `beta.1` sequence with other branches.
 
 ## PNPM Workflow (Recommended)
 
@@ -167,6 +177,7 @@ The `--prerelease` flag analyzes commits to determine the bump type and automati
 ```bash
 # With a feat commit: 1.0.0 -> 1.1.0-beta.0
 # With a fix commit: 1.0.0 -> 1.0.1-beta.0
+# With prereleaseIdentifier beta.${branchName}: 1.0.0 -> 1.1.0-beta-feature-auth-flow.0
 turboversion --prerelease
 ```
 

--- a/packages/version/src/config-schema.ts
+++ b/packages/version/src/config-schema.ts
@@ -7,7 +7,9 @@ export const versionConfigSchema = z
       .string()
       .min(1)
       .optional()
-      .describe("The prerelease identifier to use when bumping the version")
+      .describe(
+        "The prerelease identifier to use when bumping the version. Supports ${branchName}, ${packageName}, and ${target} templates."
+      )
       .default("beta"),
     tagPrefix: z
       .string()

--- a/packages/version/src/default-command/async-mode.ts
+++ b/packages/version/src/default-command/async-mode.ts
@@ -5,10 +5,10 @@ import { generateChangelog } from "../utils/generate-changelog";
 import { generateVersion } from "../utils/generate-version";
 import { generateVersionByBranchPattern } from "../utils/generate-version-by-branch-pattern";
 import { getLatestTag } from "../utils/get-latest-tag";
-import { formatCommitMessage } from "../utils/template-string";
+import { formatCommitMessage, formatPrereleaseIdentifier } from "../utils/template-string";
 import { updatePackageVersion } from "../utils/update-package-version";
 import { summarizePackages } from "../utils/dependents";
-import { gitProcess } from "../utils/git";
+import { fetchTags, gitProcess } from "../utils/git";
 import { logger } from "../utils/logger";
 import { ConfigType } from "../config-schema";
 
@@ -16,6 +16,8 @@ export async function asyncMode(config: ConfigType, type?: ReleaseType, prerelea
   const { preset, baseBranch, branchPattern = [] } = config;
 
   try {
+    await fetchTags();
+
     const packages = await summarizePackages(config);
 
     if (packages.length === 0) {
@@ -28,6 +30,7 @@ export async function asyncMode(config: ConfigType, type?: ReleaseType, prerelea
       message: `Working on package(s)`,
       details: packages.map((pkg) => pkg.packageJson.name).join(", "),
     });
+
     for (const pkg of packages) {
       const name = pkg.packageJson.name;
       const path = pkg.relativeDir;
@@ -41,6 +44,10 @@ export async function asyncMode(config: ConfigType, type?: ReleaseType, prerelea
           sync: Boolean(config.sync),
         });
         const latestTag = await getLatestTag(tagPrefix);
+        const prereleaseIdentifier = formatPrereleaseIdentifier({
+          prereleaseIdentifier: config.prereleaseIdentifier,
+          name,
+        });
 
         let version: string | null = null;
 
@@ -52,7 +59,7 @@ export async function asyncMode(config: ConfigType, type?: ReleaseType, prerelea
             path,
             branchPattern,
             baseBranch,
-            prereleaseIdentifier: config.prereleaseIdentifier,
+            prereleaseIdentifier,
           });
         } else {
           version = await generateVersion({
@@ -62,7 +69,7 @@ export async function asyncMode(config: ConfigType, type?: ReleaseType, prerelea
             type: type ?? (pkg.type as ReleaseType),
             path,
             name,
-            prereleaseIdentifier: config.prereleaseIdentifier,
+            prereleaseIdentifier,
             prerelease,
           });
         }

--- a/packages/version/src/default-command/single-mode.ts
+++ b/packages/version/src/default-command/single-mode.ts
@@ -5,10 +5,10 @@ import { generateChangelog } from "../utils/generate-changelog";
 import { generateVersion } from "../utils/generate-version";
 import { generateVersionByBranchPattern } from "../utils/generate-version-by-branch-pattern";
 import { getLatestTag } from "../utils/get-latest-tag";
-import { formatCommitMessage } from "../utils/template-string";
+import { formatCommitMessage, formatPrereleaseIdentifier } from "../utils/template-string";
 import { updatePackageVersion } from "../utils/update-package-version";
 import { logger } from "../utils/logger";
-import { gitProcess } from "../utils/git";
+import { fetchTags, gitProcess } from "../utils/git";
 import { ConfigType } from "../config-schema";
 
 export async function singleMode(config: ConfigType, options: any) {
@@ -18,6 +18,8 @@ export async function singleMode(config: ConfigType, options: any) {
   const { packages: pkgs } = getPackagesSync(cwd());
 
   try {
+    await fetchTags();
+
     const packages = pkgs
       .filter(
         (pkg) =>
@@ -35,6 +37,10 @@ export async function singleMode(config: ConfigType, options: any) {
       });
 
       const latestTag = await getLatestTag(tagPrefix);
+      const prereleaseIdentifier = formatPrereleaseIdentifier({
+        prereleaseIdentifier: config.prereleaseIdentifier,
+        name,
+      });
       let version: string | null = null;
 
       if (config.versionStrategy === "branchPattern") {
@@ -45,7 +51,7 @@ export async function singleMode(config: ConfigType, options: any) {
           path,
           branchPattern,
           baseBranch,
-          prereleaseIdentifier: config.prereleaseIdentifier,
+          prereleaseIdentifier,
         });
       } else {
         version = await generateVersion({
@@ -55,7 +61,7 @@ export async function singleMode(config: ConfigType, options: any) {
           type,
           path,
           name,
-          prereleaseIdentifier: config.prereleaseIdentifier,
+          prereleaseIdentifier,
         });
       }
 

--- a/packages/version/src/default-command/sync-mode.ts
+++ b/packages/version/src/default-command/sync-mode.ts
@@ -6,9 +6,9 @@ import { generateChangelog } from "../utils/generate-changelog";
 import { generateVersion } from "../utils/generate-version";
 import { generateVersionByBranchPattern } from "../utils/generate-version-by-branch-pattern";
 import { getLatestTag } from "../utils/get-latest-tag";
-import { formatCommitMessage } from "../utils/template-string";
+import { formatCommitMessage, formatPrereleaseIdentifier } from "../utils/template-string";
 import { updatePackageVersion } from "../utils/update-package-version";
-import { gitProcess } from "../utils/git";
+import { fetchTags, gitProcess } from "../utils/git";
 import { logger } from "../utils/logger";
 import { ConfigType } from "../config-schema";
 
@@ -21,7 +21,11 @@ export async function syncedMode(config: ConfigType, type?: ReleaseType, prerele
       sync: Boolean(config.sync),
     });
 
+    await fetchTags();
     const latestTag = await getLatestTag(tagPrefix);
+    const prereleaseIdentifier = formatPrereleaseIdentifier({
+      prereleaseIdentifier: config.prereleaseIdentifier,
+    });
 
     let version: string | null = null;
     if (config.versionStrategy === "branchPattern") {
@@ -31,7 +35,7 @@ export async function syncedMode(config: ConfigType, type?: ReleaseType, prerele
         type,
         branchPattern,
         baseBranch,
-        prereleaseIdentifier: config.prereleaseIdentifier,
+        prereleaseIdentifier,
       });
     } else {
       version = await generateVersion({
@@ -39,7 +43,7 @@ export async function syncedMode(config: ConfigType, type?: ReleaseType, prerele
         preset,
         tagPrefix,
         type,
-        prereleaseIdentifier: config.prereleaseIdentifier,
+        prereleaseIdentifier,
         prerelease,
       });
     }

--- a/packages/version/src/utils/git.ts
+++ b/packages/version/src/utils/git.ts
@@ -1,7 +1,7 @@
 import { exec, execSync as syncExec } from "node:child_process";
 import { existsSync, statSync } from "node:fs";
 import { join } from "node:path";
-import { cwd } from "node:process";
+import { cwd, env } from "node:process";
 import { promisify } from "node:util";
 
 const promisifiedExec = promisify(exec);
@@ -44,6 +44,15 @@ export async function push(branch: string, { force }: any = {}) {
 
 export async function pushTags() {
    await execAsync("git push origin --tags");
+}
+
+export async function fetchTags(remote = "origin") {
+   try {
+      await execAsync(`git fetch --tags --force ${remote}`);
+      return true;
+   } catch {
+      return false;
+   }
 }
 
 async function gitAdd(files: string[]) {
@@ -194,6 +203,11 @@ export async function lastMergeBranchName(
 
 
 export function getCurrentBranch() {
+   const branchName = env.GITHUB_HEAD_REF || env.GITHUB_REF_NAME;
+   if (branchName) {
+      return branchName;
+   }
+
    const result = execSync("git rev-parse --abbrev-ref HEAD");
    return result.toString().trim();
 }

--- a/packages/version/src/utils/template-string.ts
+++ b/packages/version/src/utils/template-string.ts
@@ -1,3 +1,5 @@
+import { getCurrentBranch } from "./git";
+
 export function createTemplateString(
    template: string,
    context: Record<string, any>,
@@ -9,6 +11,37 @@ export function createTemplateString(
          context[contextParamKey].toString(),
       );
    }, template);
+}
+
+function sanitizePrereleaseIdentifier(value: string): string {
+   return value
+      .trim()
+      .replace(/[^0-9A-Za-z-]+/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^-|-$/g, "")
+      .toLowerCase();
+}
+
+export function formatPrereleaseIdentifier({
+   prereleaseIdentifier,
+   name,
+}: {
+   prereleaseIdentifier?: string;
+   name?: string;
+}) {
+   if (!prereleaseIdentifier) {
+      return prereleaseIdentifier;
+   }
+
+   const branchName = sanitizePrereleaseIdentifier(getCurrentBranch());
+
+   const renderedIdentifier = createTemplateString(prereleaseIdentifier, {
+      branchName: branchName || "detached",
+      packageName: name ?? "",
+      target: name ?? "",
+   });
+
+   return sanitizePrereleaseIdentifier(renderedIdentifier);
 }
 
 export function formatCommitMessage({

--- a/version.config.json
+++ b/version.config.json
@@ -3,7 +3,7 @@
   "tagPrefix": "v",
   "versionStrategy": "commitMessage",
   "preset": "angular",
-  "prereleaseIdentifier": "beta",
+  "prereleaseIdentifier": "beta.${branchName}",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "sync": true,


### PR DESCRIPTION
## Summary

Fixes #26.

This updates prerelease versioning to avoid collisions between multiple branches generating prerelease tags from the same base version.

## Changes

- Fetch remote tags before version calculation so local tag state is up to date.
- Add template support for `prereleaseIdentifier`, including `${branchName}`, `${packageName}`, and `${target}`.
- Sanitize rendered prerelease identifiers into SemVer-safe values.
- Update the project config to use branch-scoped prerelease identifiers:
  `beta.${branchName}`
- Document branch-scoped prerelease streams and CI checkout/tag-fetch behavior.

## Example

A branch named `feature/auth-flow` with:

```json
{
  "prereleaseIdentifier": "beta.${branchName}"
}
